### PR TITLE
feat: add KubeStellar Console to Specification/Solution/Project section

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Glossary Repos: https://github.com/PECommunity/platform-engineering-glossary
 - KusionStack https://kusionstack.io/ Open Tech Stack to build self-service, collaborative, reliable and sustainable Internal Developer Platform.
 - BACK Stack https://backstack.dev/ Build a Developer Platform in seconds: Backstage | Argo CD | Crossplane | Kyverno
 - CNOE https://cnoe.io/ Cloud Native Operational Excellence | CNOE aims at helping platform engineers build their IDP platforms faster and in a more secure way with best practices built in
+- KubeStellar Console https://github.com/kubestellar/console Open source AI-powered multi-cluster Kubernetes dashboard with real-time observability, AI-guided operations, CNCF integrations (Argo, Kyverno, Prometheus, and 20+ others), and edge/cloud cluster management. CNCF Sandbox project.
 
 ## <span id="3">3. Conf/Event  会议/活动</span>
 - PlatformCon https://platformcon.com 


### PR DESCRIPTION
## Description

Adds [KubeStellar Console](https://github.com/kubestellar/console) to the Specification/Solution/Project section.

KubeStellar Console is an open source AI-powered multi-cluster Kubernetes platform dashboard that platform engineers use to:
- Manage multiple Kubernetes clusters across edge and cloud from a single pane of glass
- Leverage AI-guided operations and troubleshooting
- Integrate 20+ CNCF projects: Argo, Kyverno, Prometheus, Grafana, Istio, Flux, and more
- Provide compliance dashboards for security posture management
- CNCF Sandbox project with active open source community