### PR TITLE
Add Ownkube to Specification/Solution/Project

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Glossary Repos: https://github.com/PECommunity/platform-engineering-glossary
 - BACK Stack https://backstack.dev/ Build a Developer Platform in seconds: Backstage | Argo CD | Crossplane | Kyverno
 - CNOE https://cnoe.io/ Cloud Native Operational Excellence | CNOE aims at helping platform engineers build their IDP platforms faster and in a more secure way with best practices built in
 - KubeStellar Console https://github.com/kubestellar/console Multi-cluster Kubernetes dashboard with AI-powered operations, real-time observability, and 20+ CNCF project integrations | CNCF Sandbox project for edge-to-cloud platform management [Demo](https://console.kubestellar.io)
+- Ownkube https://ownkube.io AI-enabled developer platform that runs in your own AWS account on k3s or EKS. Git-push deploys, managed Postgres, preview environments per PR, AI error detection. Free on single-node k3s.
 
 ## <span id="3">3. Conf/Event  会议/活动</span>
 - PlatformCon https://platformcon.com 


### PR DESCRIPTION
Adds [Ownkube](https://ownkube.io) under section **2. Specification/Solution/Project**.

Ownkube is an AI-enabled developer platform that runs in the user's own AWS account on top of k3s or EKS. It gives platform teams (or teams who don't have one) a Heroku-style developer experience on infrastructure they own. Free on single-node k3s; usage-based on EKS multi-node ($10/vCPU + $5/GB RAM per month).

Fits the section alongside Argonaut, Humanitec, Mia Platform, KubeVela, and Qovery.