### PR TITLE
Add Fortem: AI-native self-hosted Kubernetes IDP

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Glossary Repos: https://github.com/PECommunity/platform-engineering-glossary
 - Humanitec https://humanitec.com/ Powering your Internal Developer Platform
 - Backstage https://backstage.io/ An open platform for building developer portals | Software catalog and developer platform [Demo](https://demo.backstage.io/)
 - Devtron https://devtron.ai/ An open source Internal Developer Platform for Kubernetes
+- Fortem https://fortem.dev/ AI-native Internal Developer Platform for Kubernetes — self-hosted, single Helm chart install, NL-to-manifest generation, AIOps cost optimization, zero vendor lock-in
 - GetPort https://www.getport.io/ A No-Code Developer Portal  [Demo](https://demo.getport.io/)
 - Roadie https://roadie.io/ Roadie:  SaaS Backstage. Simple, safe, and more powerful
 - zymr https://www.zymr.com/product-platform-engineering-services ZYMR: WE EXCEL AT PLATFORM ENGINEERING   


### PR DESCRIPTION
## What is Fortem?

**[Fortem](https://fortem.dev)** is an AI-native Internal Developer Platform for Kubernetes, designed for teams who want the power of a full IDP without dedicating a platform team to maintain it.

**Why it belongs here:**
- Self-hosted — installs as a single Helm chart inside your cluster, no external SaaS dependency
- AI-first architecture — NL-to-K8s manifest generation, AIOps idle detection, incident diagnosis, right-sizing engine
- Kubernetes Operator model — environment state declared as CRDs, fully GitOps-compatible
- Zero vendor lock-in — every object is a standard K8s CRD, exportable via kubectl get
- Open Community tier — free forever, 1 cluster

It fits naturally alongside Backstage, Devtron, and Humanitec as a self-hosted IDP option, with a distinct focus on AI-native operations and minimal platform team overhead.

**Links:** [fortem.dev](https://fortem.dev) · [Docs](https://fortem.dev/docs)
